### PR TITLE
fix(payments): rename API DTOs to avoid conflict with webhook DTOs

### DIFF
--- a/apps/landing/backend/src/JEGASolutions.Landing.Application/DTOs/WompiApiDtos.cs
+++ b/apps/landing/backend/src/JEGASolutions.Landing.Application/DTOs/WompiApiDtos.cs
@@ -2,13 +2,19 @@ using System.Text.Json.Serialization;
 
 namespace JEGASolutions.Landing.Application.DTOs;
 
+/// <summary>
+/// Respuesta de la API de Wompi al crear una transacción
+/// </summary>
 public class WompiApiResponseDto
 {
     [JsonPropertyName("data")]
-    public WompiTransactionDataDto? Data { get; set; }
+    public WompiApiTransactionDto? Data { get; set; }
 }
 
-public class WompiTransactionDataDto
+/// <summary>
+/// Datos de la transacción devueltos por la API de Wompi
+/// </summary>
+public class WompiApiTransactionDto
 {
     [JsonPropertyName("id")]
     public string? Id { get; set; }
@@ -20,18 +26,27 @@ public class WompiTransactionDataDto
     public string? Status { get; set; }
 }
 
+/// <summary>
+/// Respuesta del endpoint de merchants de Wompi
+/// </summary>
 public class WompiMerchantResponseDto
 {
     [JsonPropertyName("data")]
     public WompiMerchantDataDto? Data { get; set; }
 }
 
+/// <summary>
+/// Datos del merchant
+/// </summary>
 public class WompiMerchantDataDto
 {
     [JsonPropertyName("presigned_acceptance")]
     public PresignedAcceptanceDto? PresignedAcceptance { get; set; }
 }
 
+/// <summary>
+/// Token de aceptación pre-firmado
+/// </summary>
 public class PresignedAcceptanceDto
 {
     [JsonPropertyName("acceptance_token")]


### PR DESCRIPTION
- Rename WompiTransactionDataDto to WompiApiTransactionDto in WompiApiDtos.cs
- Prevents namespace conflict with WompiWebhookDto.cs
- Both files now have unique class names